### PR TITLE
Add action to close swipebox from mouse click somewhere outside the image. Not on touch

### DIFF
--- a/source/jquery.swipebox.js
+++ b/source/jquery.swipebox.js
@@ -419,10 +419,10 @@
 				});
 
 				$('#swipebox-slider .slide').bind('click', function (e) {
-		                	if (e.target === this) {
-                				$this.closeSlide();
-                			}
-                		});
+					if (e.target === this) {
+						$this.closeSlide();
+					}
+				});
 			},
 
 			setSlide : function (index, isFirst) {


### PR DESCRIPTION
Tested on iPad 1, Chrome, Chrome with touch events (developer tools). 

On touch this PR changes nothing, with mouse it closes the swipebox when clicking outside the image.
