### PR TITLE
Change z-index to position:relative for close/prev/next buttons

### DIFF
--- a/source/swipebox.css
+++ b/source/swipebox.css
@@ -138,7 +138,7 @@ html.swipebox {
   width: 50px;
   height: 50px;
   display: inline-block;
-  z-index: 1;
+  position: relative;
 }
 
 #swipebox-close {


### PR DESCRIPTION
As the parent is positioned absolute, z-index doesn't get it right and prevents clicking the buttons. position: relative does the right thing (tm)
