### PR TITLE
Use .text instead of .append in setTitle, to prevent rendering title as html

### DIFF
--- a/source/jquery.shinybox.js
+++ b/source/jquery.shinybox.js
@@ -502,7 +502,7 @@
 					title = elements[index].title;
 				}
 				if (title) {
-					$('#shinybox-caption').append(title);
+					$('#shinybox-caption').text(title);
 				}
 			},
 


### PR DESCRIPTION
We don't want someone to inject script tags via the title :)
