### PR TITLE
Allow scoping the stylesheets for shinybox #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ pip-log.txt
 # Sublime Text 2
 *.sublime-project
 *.sublime-workspace
+
+# npm
+node_modules/

--- a/package.json
+++ b/package.json
@@ -4,5 +4,12 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/One-com/shinybox/"
+  },
+  "devDependencies": {
+    "less": "2.5.3",
+    "less-plugin-autoprefix": "^1.5.1"
+  },
+  "scripts": {
+    "prepublish": "./node_modules/less/bin/lessc --autoprefix=\"last 2 versions, ie >= 10\" source/import.less > source/shinybox.css"
   }
 }

--- a/source/import.less
+++ b/source/import.less
@@ -1,0 +1,9 @@
+@import 'shinybox.less';
+
+html.shinybox {
+    overflow: hidden!important;
+}
+
+#shinybox-overlay {
+    .shinybox-overlay();
+}

--- a/source/jquery.shinybox.js
+++ b/source/jquery.shinybox.js
@@ -34,7 +34,8 @@
         supportSVG = !!(window.SVGSVGElement),
         winWidth = window.innerWidth ? window.innerWidth : $(window).width(),
         winHeight = window.innerHeight ? window.innerHeight : $(window).height(),
-        html = '';
+        html = '',
+        id = 'shinybox-overlay';
 
         plugin.settings = {};
 
@@ -43,28 +44,30 @@
             plugin.settings = $.extend({}, defaults, options);
             var htmlTop = '', htmlBottom = '';
             if (plugin.settings.closePlacement === 'top') {
-                htmlTop += '<a id="shinybox-close"></a>';
+                htmlTop += '<a class="shinybox-close"></a>';
             } else if (plugin.settings.closePlacement === 'bottom') {
-                htmlBottom += '<a id="shinybox-close"></a>';
+                htmlBottom += '<a class="shinybox-close"></a>';
             }
             if (plugin.settings.captionPlacement === 'top') {
-                htmlTop += '<div id="shinybox-caption"></div>';
+                htmlTop += '<div class="shinybox-caption"></div>';
             } else if (plugin.settings.captionPlacement === 'bottom') {
-                htmlBottom += '<div id="shinybox-caption"></div>';
+                htmlBottom += '<div class="shinybox-caption"></div>';
             }
             if (plugin.settings.navigationPlacement === 'top') {
-                htmlTop += '<a id="shinybox-prev"></a>' +
-                    '<a id="shinybox-next"></a>';
+                htmlTop += '<a class="shinybox-prev"></a>' +
+                    '<a class="shinybox-next"></a>';
             } else if (plugin.settings.navigationPlacement === 'bottom') {
-                htmlBottom += '<a id="shinybox-prev"></a>' +
-                    '<a id="shinybox-next"></a>';
+                htmlBottom += '<a class="shinybox-prev"></a>' +
+                    '<a class="shinybox-next"></a>';
             }
-        html = '<div id="shinybox-overlay">' +
-            '<div id="shinybox-slider"></div>' +
-            '<div id="shinybox-top">' +
+            id = plugin.settings.id || id;
+
+        html = '<div id="' + id + '" class="shinybox-overlay">' +
+            '<div class="shinybox-slider"></div>' +
+            '<div class="shinybox-top">' +
             htmlTop +
             '</div>' +
-            '<div id="shinybox-bottom">' +
+            '<div class="shinybox-bottom">' +
             htmlBottom +
             '</div>' +
             '</div>';
@@ -145,21 +148,21 @@
                 $('body').append(html);
 
                 if ($this.doCssTrans()) {
-                    $('#shinybox-slider').css({
+                    $('.shinybox-slider').css({
                         '-webkit-transition' : 'left 0.4s ease',
                         '-moz-transition' : 'left 0.4s ease',
                         '-o-transition' : 'left 0.4s ease',
                         '-khtml-transition' : 'left 0.4s ease',
                         'transition' : 'left 0.4s ease'
                     });
-                    $('#shinybox-overlay').css({
+                    $('.shinybox-overlay').css({
                         '-webkit-transition' : 'opacity 1s ease',
                         '-moz-transition' : 'opacity 1s ease',
                         '-o-transition' : 'opacity 1s ease',
                         '-khtml-transition' : 'opacity 1s ease',
                         'transition' : 'opacity 1s ease'
                     });
-                    $('#shinybox-bottom, #shinybox-top').css({
+                    $('.shinybox-bottom, .shinybox-top').css({
                         '-webkit-transition' : '0.5s',
                         '-moz-transition' : '0.5s',
                         '-o-transition' : '0.5s',
@@ -170,15 +173,15 @@
 
 
                 if (supportSVG) {
-                    var bg = $('#shinybox-close').css('background-image');
+                    var bg = $('.shinybox-close').css('background-image');
                     bg = bg.replace('png', 'svg');
-                    $('#shinybox-prev,#shinybox-next,#shinybox-close').css({
+                    $('.shinybox-prev,.shinybox-next,.shinybox-close').css({
                         'background-image' : bg
                     });
                 }
 
                 $.each(elements, function () {
-                    $('#shinybox-slider').append('<div class="slide"></div>');
+                    $('.shinybox-slider').append('<div class="slide"></div>');
                 });
 
                 $this.setDim();
@@ -216,14 +219,14 @@
                 };
 
 
-                $('#shinybox-overlay').css(sliderCss);
+                $('.shinybox-overlay').css(sliderCss);
                 if (plugin.settings.hideBarsDelay === 0) {
-                    $('#shinybox-slider').css({
+                    $('.shinybox-slider').css({
                         top: '50px',
                         height: (height - 100) + 'px'
                     });
                 } else {
-                    $('#shinybox-slider').css({
+                    $('.shinybox-slider').css({
                         top: 0,
                         height: '100%'
                     });
@@ -261,7 +264,7 @@
                     swipMinDistance = 10,
                     startCoords = {},
                     endCoords = {};
-                    var bars = $('#shinybox-top, #shinybox-bottom');
+                    var bars = $('.shinybox-top, .shinybox-bottom');
 
                     bars.addClass('visible-bars');
                     $this.setTimeout();
@@ -334,12 +337,12 @@
             },
 
             showBars : function () {
-                var bars = $('#shinybox-top, #shinybox-bottom');
+                var bars = $('.shinybox-top, .shinybox-bottom');
                 if (this.doCssTrans()) {
                     bars.addClass('visible-bars');
                 } else {
-                    $('#shinybox-top').animate({ top : 0 }, 500);
-                    $('#shinybox-bottom').animate({ bottom : 0 }, 500);
+                    $('.shinybox-top').animate({ top : 0 }, 500);
+                    $('.shinybox-bottom').animate({ bottom : 0 }, 500);
                     setTimeout(function () {
                         bars.addClass('visible-bars');
                     }, 1000);
@@ -347,12 +350,12 @@
             },
 
             hideBars : function () {
-                var bars = $('#shinybox-top, #shinybox-bottom');
+                var bars = $('.shinybox-top, .shinybox-bottom');
                 if (this.doCssTrans()) {
                     bars.removeClass('visible-bars');
                 } else {
-                    $('#shinybox-top').animate({ top : '-50px' }, 500);
-                    $('#shinybox-bottom').animate({ bottom : '-50px' }, 500);
+                    $('.shinybox-top').animate({ top : '-50px' }, 500);
+                    $('.shinybox-bottom').animate({ bottom : '-50px' }, 500);
                     setTimeout(function () {
                         bars.removeClass('visible-bars');
                     }, 1000);
@@ -361,19 +364,19 @@
 
             animBars : function () {
                 var $this = this;
-                var bars = $('#shinybox-top, #shinybox-bottom');
+                var bars = $('.shinybox-top, .shinybox-bottom');
 
                 bars.addClass('visible-bars');
                 $this.setTimeout();
 
-                $('#shinybox-slider').click(function (e) {
+                $('.shinybox-slider').click(function (e) {
                     if (!bars.hasClass('visible-bars')) {
                         $this.showBars();
                         $this.setTimeout();
                     }
                 });
 
-                $('#shinybox-bottom').hover(
+                $('.shinybox-bottom').hover(
                     function () {
                         $this.showBars();
                         bars.addClass('force-visible-bars');
@@ -407,16 +410,16 @@
                 var $this = this;
 
                 if (elements.length < 2) {
-                    $('#shinybox-prev, #shinybox-next').hide();
+                    $('.shinybox-prev, .shinybox-next').hide();
                 } else {
-                    $('#shinybox-prev').bind('click touchend', function (e) {
+                    $('.shinybox-prev').bind('click touchend', function (e) {
                         e.preventDefault();
                         e.stopPropagation();
                         $this.getPrev();
                         $this.setTimeout();
                     });
 
-                    $('#shinybox-next').bind('click touchend', function (e) {
+                    $('.shinybox-next').bind('click touchend', function (e) {
                         e.preventDefault();
                         e.stopPropagation();
                         $this.getNext();
@@ -424,11 +427,11 @@
                     });
                 }
 
-                $('#shinybox-close').bind('click touchend', function (e) {
+                $('.shinybox-close').bind('click touchend', function (e) {
                     $this.closeSlide();
                 });
 
-                $('#shinybox-slider .slide').bind('click', function (e) {
+                $('.shinybox-slider .slide').bind('click', function (e) {
                     if (e.target === this) {
                         $this.closeSlide();
                     }
@@ -438,7 +441,7 @@
             setSlide : function (index, isFirst) {
                 isFirst = isFirst || false;
 
-                var slider = $('#shinybox-slider');
+                var slider = $('.shinybox-slider');
 
                 if (this.doCssTrans()) {
                     slider.css({ left : (-index * 100) + '%' });
@@ -446,19 +449,19 @@
                     slider.animate({ left : (-index * 100) + '%' });
                 }
 
-                $('#shinybox-slider .slide').removeClass('current');
-                $('#shinybox-slider .slide').eq(index).addClass('current');
+                $('.shinybox-slider .slide').removeClass('current');
+                $('.shinybox-slider .slide').eq(index).addClass('current');
                 this.setTitle(index);
 
                 if (isFirst) {
                     slider.fadeIn();
                 }
 
-                $('#shinybox-prev, #shinybox-next').removeClass('disabled');
+                $('.shinybox-prev, .shinybox-next').removeClass('disabled');
                 if (index === 0) {
-                    $('#shinybox-prev').addClass('disabled');
+                    $('.shinybox-prev').addClass('disabled');
                 } else if (index === elements.length - 1) {
-                    $('#shinybox-next').addClass('disabled');
+                    $('.shinybox-next').addClass('disabled');
                 }
             },
 
@@ -493,7 +496,7 @@
                     return false;
                 }
 
-                var $element = $('#shinybox-slider .slide').eq(index);
+                var $element = $('.shinybox-slider .slide').eq(index);
                 if ($this.isVideo(src)) {
                     $element.html($this.getVideo(src));
                 } else if ($this.isPDF(src)) {
@@ -509,13 +512,13 @@
             setTitle : function (index, isFirst) {
                 var title = null;
 
-                $('#shinybox-caption').empty();
+                $('.shinybox-caption').empty();
 
                 if (elements[index] !== undefined) {
                     title = elements[index].title;
                 }
                 if (title) {
-                    $('#shinybox-caption').text(title);
+                    $('.shinybox-caption').text(title);
                 }
             },
 
@@ -568,34 +571,33 @@
 
             getNext : function () {
                 var $this = this,
-                    index = $('#shinybox-slider .slide').index($('#shinybox-slider .slide.current'));
+                    index = $('.shinybox-slider .slide').index($('.shinybox-slider .slide.current'));
                 if (index + 1 < elements.length) {
                     index += 1;
                     $this.setSlide(index);
                     $this.preloadMedia(index + 1);
                 } else {
 
-                    $('#shinybox-slider').addClass('rightSpring');
+                    $('.shinybox-slider').addClass('rightSpring');
                     setTimeout(function () {
-                        $('#shinybox-slider').removeClass('rightSpring');
+                        $('.shinybox-slider').removeClass('rightSpring');
                     }, 500);
                 }
             },
 
             getPrev : function () {
-                var index = $('#shinybox-slider .slide').index($('#shinybox-slider .slide.current'));
+                var index = $('.shinybox-slider .slide').index($('.shinybox-slider .slide.current'));
                 if (index > 0) {
                     index -= 1;
                     this.setSlide(index);
                     this.preloadMedia(index - 1);
                 } else {
-                    $('#shinybox-slider').addClass('leftSpring');
+                    $('.shinybox-slider').addClass('leftSpring');
                     setTimeout(function () {
-                        $('#shinybox-slider').removeClass('leftSpring');
+                        $('.shinybox-slider').removeClass('leftSpring');
                     }, 500);
                 }
             },
-
 
             closeSlide : function () {
                 $('html').removeClass('shinybox');
@@ -608,8 +610,8 @@
                 $('body').unbind('touchstart');
                 $('body').unbind('touchmove');
                 $('body').unbind('touchend');
-                $('#shinybox-slider').unbind();
-                $('#shinybox-overlay').remove();
+                $('.shinybox-slider').unbind();
+                $('.shinybox-overlay').remove();
                 if (!$.isArray(elem))
                     elem.removeData('_shinybox');
                 if (this.target)

--- a/source/shinybox.css
+++ b/source/shinybox.css
@@ -1,11 +1,6 @@
 html.shinybox {
   overflow: hidden!important;
 }
-
-#shinybox-overlay img {
-  border: none!important;
-}
-
 #shinybox-overlay {
   width: 100%;
   height: 100%;
@@ -15,11 +10,59 @@ html.shinybox {
   z-index: 99999!important;
   overflow: hidden;
   -webkit-user-select: none;
-  -moz-user-select: none;
-  user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  background: rgba(13, 13, 13, 0.6);
 }
-
-#shinybox-slider {
+@-webkit-keyframes rightSpring {
+  0% {
+    margin-left: 0px;
+  }
+  50% {
+    margin-left: -30px;
+  }
+  100% {
+    margin-left: 0px;
+  }
+}
+@keyframes rightSpring {
+  0% {
+    margin-left: 0px;
+  }
+  50% {
+    margin-left: -30px;
+  }
+  100% {
+    margin-left: 0px;
+  }
+}
+@-webkit-keyframes leftSpring {
+  0% {
+    margin-left: 0px;
+  }
+  50% {
+    margin-left: 30px;
+  }
+  100% {
+    margin-left: 0px;
+  }
+}
+@keyframes leftSpring {
+  0% {
+    margin-left: 0px;
+  }
+  50% {
+    margin-left: 30px;
+  }
+  100% {
+    margin-left: 0px;
+  }
+}
+#shinybox-overlay img {
+  border: none!important;
+}
+#shinybox-overlay #shinybox-slider {
   height: 100%;
   left: 0;
   top: 0;
@@ -28,8 +71,15 @@ html.shinybox {
   position: absolute;
   display: none;
 }
-
-#shinybox-slider .slide {
+#shinybox-overlay #shinybox-slider.rightSpring {
+  -webkit-animation: rightSpring 0.3s;
+          animation: rightSpring 0.3s;
+}
+#shinybox-overlay #shinybox-slider.leftSpring {
+  -webkit-animation: leftSpring 0.3s;
+          animation: leftSpring 0.3s;
+}
+#shinybox-overlay #shinybox-slider .slide {
   height: 100%;
   width: 98%;
   line-height: 1px;
@@ -37,25 +87,16 @@ html.shinybox {
   display: inline-block;
   margin: 0 1%;
 }
-
-#shinybox-slider .loading {
-  background: url("img/loader.gif") no-repeat center center;
-  height: 31px;
-  width: 31px;
-  margin: auto;
-}
-
-#shinybox-slider .slide:before {
+#shinybox-overlay #shinybox-slider .slide:before {
   content: "";
   display: inline-block;
   height: 50%;
   width: 1px;
   margin-right: -1px;
 }
-
-#shinybox-slider .slide img,
-#shinybox-slider .slide .shinybox-video-container,
-#shinybox-slider .slide .shinybox-pdf-container {
+#shinybox-overlay #shinybox-slider .slide img,
+#shinybox-overlay #shinybox-slider .slide .shinybox-video-container,
+#shinybox-overlay #shinybox-slider .slide .shinybox-pdf-container {
   display: inline-block;
   max-height: 100%;
   max-width: 100%;
@@ -65,84 +106,90 @@ html.shinybox {
   height: auto;
   vertical-align: middle;
 }
-
-#shinybox-slider .slide .shinybox-video-container {
-  background:none;
+#shinybox-overlay #shinybox-slider .slide .shinybox-video-container {
+  background: none;
   max-width: 1140px;
   max-height: 100%;
   width: 100%;
-  padding:5%;
+  padding: 5%;
   box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
 }
-
-#shinybox-slider .slide .shinybox-video-container .shinybox-video {
+#shinybox-overlay #shinybox-slider .slide .shinybox-video-container .shinybox-video {
   width: 100%;
   height: 0;
   padding-bottom: 56.25%;
   overflow: hidden;
   position: relative;
 }
-
-#shinybox-slider .slide .shinybox-pdf-container {
-  background:none;
+#shinybox-overlay #shinybox-slider .slide .shinybox-video-container .shinybox-video iframe {
+  width: 100%!important;
+  height: 100%!important;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+#shinybox-overlay #shinybox-slider .slide .shinybox-pdf-container {
+  background: none;
   max-width: 1140px;
   height: 100%;
   width: 100%;
   box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
 }
-
-#shinybox-slider .slide .shinybox-pdf-container .shinybox-pdf {
+#shinybox-overlay #shinybox-slider .slide .shinybox-pdf-container .shinybox-pdf {
   height: 100%;
   width: 100%;
   overflow: hidden;
   position: relative;
 }
-
-#shinybox-slider .slide .shinybox-video-container .shinybox-video iframe,
-#shinybox-slider .slide .shinybox-pdf-container .shinybox-pdf iframe {
+#shinybox-overlay #shinybox-slider .slide .shinybox-pdf-container .shinybox-pdf iframe {
   width: 100%!important;
   height: 100%!important;
   position: absolute;
-  top: 0; left: 0;
+  top: 0;
+  left: 0;
 }
-
-#shinybox-bottom, #shinybox-top {
+#shinybox-overlay #shinybox-slider .loading {
+  background: url("img/loader.gif") no-repeat center center;
+  height: 31px;
+  width: 31px;
+  margin: auto;
+}
+#shinybox-overlay #shinybox-bottom,
+#shinybox-overlay #shinybox-top {
   position: absolute;
   left: 0;
   z-index: 999;
   height: 50px;
   width: 100%;
+  text-shadow: 1px 1px 1px black;
+  background-color: #0d0d0d;
+  background-image: linear-gradient(#0d0d0d, #000000);
+  opacity: 0.95;
 }
-
-#shinybox-bottom {
-  text-align: right;
-  bottom: -50px;
-}
-#shinybox-bottom.visible-bars {
-  bottom: 0;
-}
-
-#shinybox-bottom.force-visible-bars {
-  bottom: 0!important;
-}
-
-#shinybox-top {
+#shinybox-overlay #shinybox-top {
   top: -50px;
 }
-#shinybox-top.visible-bars {
+#shinybox-overlay #shinybox-top.visible-bars {
   top: 0;
 }
-
-#shinybox-top.force-visible-bars {
+#shinybox-overlay #shinybox-top.force-visible-bars {
   top: 0!important;
 }
-
-#shinybox-prev, #shinybox-next,
-#shinybox-close {
+#shinybox-overlay #shinybox-bottom {
+  text-align: right;
+  bottom: -50px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+#shinybox-overlay #shinybox-bottom.visible-bars {
+  bottom: 0;
+}
+#shinybox-overlay #shinybox-bottom.force-visible-bars {
+  bottom: 0!important;
+}
+#shinybox-overlay #shinybox-prev,
+#shinybox-overlay #shinybox-next,
+#shinybox-overlay #shinybox-close {
   background-image: url("img/icons.svg");
   background-repeat: no-repeat;
   border: none!important;
@@ -154,116 +201,23 @@ html.shinybox {
   position: relative;
   z-index: 1;
 }
-
-#shinybox-close {
+#shinybox-overlay #shinybox-close {
   background-position: 15px 12px;
   float: left;
 }
-
-#shinybox-prev {
+#shinybox-overlay #shinybox-prev {
   background-position: -32px 13px;
 }
-
-#shinybox-next {
-  background-position: -78px 13px;
-}
-
-#shinybox-prev.disabled,
-#shinybox-next.disabled {
-  filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=30);
+#shinybox-overlay #shinybox-prev.disabled {
   opacity: 0.3;
 }
-
-#shinybox-slider.rightSpring {
-  -moz-animation: rightSpring 0.3s;
-  -webkit-animation: rightSpring 0.3s;
+#shinybox-overlay #shinybox-next {
+  background-position: -78px 13px;
 }
-
-#shinybox-slider.leftSpring {
-  -moz-animation: leftSpring 0.3s;
-  -webkit-animation: leftSpring 0.3s;
+#shinybox-overlay #shinybox-next.disabled {
+  opacity: 0.3;
 }
-
-@-moz-keyframes rightSpring {
-  0% {
-    margin-left: 0px;
-  }
-
-  50% {
-    margin-left: -30px;
-  }
-
-  100% {
-    margin-left: 0px;
-  }
-}
-
-@-moz-keyframes leftSpring {
-  0% {
-    margin-left: 0px;
-  }
-
-  50% {
-    margin-left: 30px;
-  }
-
-  100% {
-    margin-left: 0px;
-  }
-}
-
-@-webkit-keyframes rightSpring {
-  0% {
-    margin-left: 0px;
-  }
-
-  50% {
-    margin-left: -30px;
-  }
-
-  100% {
-    margin-left: 0px;
-  }
-}
-
-@-webkit-keyframes leftSpring {
-  0% {
-    margin-left: 0px;
-  }
-
-  50% {
-    margin-left: 30px;
-  }
-
-  100% {
-    margin-left: 0px;
-  }
-}
-
-/* Skin
---------------------------*/
-#shinybox-overlay {
-  background: rgba(13, 13, 13, 0.6);
-}
-
-#shinybox-bottom, #shinybox-top {
-  text-shadow: 1px 1px 1px black;
-  background-color: #0d0d0d;
-  background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #0d0d0d), color-stop(100%, #000000));
-  background-image: -webkit-linear-gradient(#0d0d0d, #000000);
-  background-image: -moz-linear-gradient(#0d0d0d, #000000);
-  background-image: -o-linear-gradient(#0d0d0d, #000000);
-  background-image: linear-gradient(#0d0d0d, #000000);
-  filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=95);
-  opacity: 0.95;
-}
-
-#shinybox-bottom {
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-#shinybox-caption {
+#shinybox-overlay #shinybox-caption {
   color: white!important;
   font-size: 15px;
   line-height: 50px;

--- a/source/shinybox.less
+++ b/source/shinybox.less
@@ -1,0 +1,227 @@
+.shinybox-overlay() {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 99999!important;
+    overflow: hidden;
+    user-select: none;
+    background: rgba(13, 13, 13, 0.6);
+
+    @keyframes rightSpring {
+        0% {
+            margin-left: 0px;
+        }
+
+        50% {
+            margin-left: -30px;
+        }
+
+        100% {
+            margin-left: 0px;
+        }
+    }
+
+    @keyframes leftSpring {
+        0% {
+            margin-left: 0px;
+        }
+
+        50% {
+            margin-left: 30px;
+        }
+
+        100% {
+            margin-left: 0px;
+        }
+    }
+
+    img {
+        border: none!important;
+    }
+
+    .shinybox-slider {
+        height: 100%;
+        left: 0;
+        top: 0;
+        width: 100%;
+        white-space: nowrap;
+        position: absolute;
+        display: none;
+
+        &.rightSpring {
+            animation: rightSpring 0.3s;
+            animation: rightSpring 0.3s;
+        }
+
+        &.leftSpring {
+            animation: leftSpring 0.3s;
+            animation: leftSpring 0.3s;
+        }
+
+        .slide {
+            height: 100%;
+            width: 98%;
+            line-height: 1px;
+            text-align: center;
+            display: inline-block;
+            margin: 0 1%;
+
+            &:before {
+                content: "";
+                display: inline-block;
+                height: 50%;
+                width: 1px;
+                margin-right: -1px;
+            }
+
+            img, .shinybox-video-container, .shinybox-pdf-container {
+                display: inline-block;
+                max-height: 100%;
+                max-width: 100%;
+                margin: 0;
+                padding: 0;
+                width: auto;
+                height: auto;
+                vertical-align: middle;
+            }
+
+            .iframe() {
+                width: 100%!important;
+                height: 100%!important;
+                position: absolute;
+                top: 0; left: 0;
+            }
+
+            .shinybox-video-container {
+                background:none;
+                max-width: 1140px;
+                max-height: 100%;
+                width: 100%;
+                padding:5%;
+                box-sizing: border-box;
+
+                .shinybox-video {
+                    width: 100%;
+                    height: 0;
+                    padding-bottom: 56.25%;
+                    overflow: hidden;
+                    position: relative;
+
+                    iframe {
+                        .iframe;
+                    }
+                }
+            }
+
+            .shinybox-pdf-container {
+                background:none;
+                max-width: 1140px;
+                height: 100%;
+                width: 100%;
+                box-sizing: border-box;
+
+                .shinybox-pdf {
+                    height: 100%;
+                    width: 100%;
+                    overflow: hidden;
+                    position: relative;
+
+                    iframe {
+                        .iframe;
+                    }
+                }
+            }
+        }
+
+        .loading {
+            background: url("img/loader.gif") no-repeat center center;
+            height: 31px;
+            width: 31px;
+            margin: auto;
+        }
+    }
+
+    .shinybox-bottom, .shinybox-top {
+        position: absolute;
+        left: 0;
+        z-index: 999;
+        height: 50px;
+        width: 100%;
+        text-shadow: 1px 1px 1px black;
+        background-color: #0d0d0d;
+        background-image: linear-gradient(#0d0d0d, #000000);
+        opacity: 0.95;
+    }
+
+    .shinybox-top {
+        top: -50px;
+
+        &.visible-bars {
+            top: 0;
+        }
+
+        &.force-visible-bars {
+            top: 0!important;
+        }
+    }
+
+    .shinybox-bottom {
+        text-align: right;
+        bottom: -50px;
+        border-top: 1px solid rgba(255, 255, 255, 0.2);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+
+        &.visible-bars {
+            bottom: 0;
+        }
+
+        &.force-visible-bars {
+            bottom: 0!important;
+        }
+    }
+
+    .shinybox-prev, .shinybox-next,
+    .shinybox-close {
+        background-image: url("img/icons.svg");
+        background-repeat: no-repeat;
+        border: none!important;
+        text-decoration: none!important;
+        cursor: pointer;
+        width: 50px;
+        height: 50px;
+        display: inline-block;
+        position: relative;
+        z-index: 1;
+    }
+
+    .shinybox-close {
+        background-position: 15px 12px;
+        float: left;
+    }
+
+    .shinybox-prev {
+        background-position: -32px 13px;
+
+        &.disabled {
+            opacity: 0.3;
+        }
+    }
+
+    .shinybox-next {
+        background-position: -78px 13px;
+
+        &.disabled {
+            opacity: 0.3;
+        }
+    }
+
+    .shinybox-caption {
+        color: white!important;
+        font-size: 15px;
+        line-height: 50px;
+        font-family: Helvetica, Arial, sans-serif;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
Also removed ids of referenced child elements into class names since there is only one shinybox active at one time anyway.