### PR TITLE
Fix wrong width/height calculation when page has been scrolled down

### DIFF
--- a/source/jquery.shinybox.js
+++ b/source/jquery.shinybox.js
@@ -202,13 +202,8 @@
 
                 if ("onorientationchange" in window) {
                     var calculateWidthAndHeight = function () {
-                        if (window.orientation === 0) {
-                            width = winWidth;
-                            height = winHeight;
-                        } else if (window.orientation === 90 || window.orientation === -90) {
-                            width = winHeight;
-                            height = winWidth;
-                        }
+                        width = window.innerWidth ? window.innerWidth : $(window).width();
+                        height = window.innerHeight ? window.innerHeight : $(window).height();
                     };
                     calculateWidthAndHeight();
                     window.addEventListener("orientationchange", function () {


### PR DESCRIPTION
Hi Team,
I have changed the calculation of width and height of shiny box as in mobiles the height of window will keep changing when the user scrolls(It would be reduced when toolbar is shown and increased when toolbar disappears. This happens on scroll of a page. So removed the constant height and used window.innerHeight. I have tested it in phones( Android device, Iphone and Ipad) and on pc(Chrome, safari(mac), firefox and IE) preview in both desktop and mobile view. It works fine. The problem with the previos code can be seen in issue https://jira.one.com/browse/ONEWEB-10139
Thanks,
Sathish